### PR TITLE
Fix models that use names now blocked by modal model keywords

### DIFF
--- a/C/Savina/src/concurrency/BoundedBuffer.lf
+++ b/C/Savina/src/concurrency/BoundedBuffer.lf
@@ -162,10 +162,10 @@ reactor ProducerReactor(bank_index: size_t(0), numItemsToProduce: size_t(1000), 
     input produce: bool;
     output data: double
     
-    input reset: bool;
+    input reset_state: bool;
     output finished: bool;
     
-    reaction (reset) {=   
+    reaction (reset_state) {=   
         // reset local state
         self->prodItem = 0.0;
         self->itemsProduced = 0;
@@ -187,14 +187,14 @@ reactor ConsumerReactor(bank_index: size_t(0), consCost: size_t(25)) {
     
     state consItem: double(0.0);
     
-    input reset: bool;
+    input reset_state: bool;
 
     input data: double;
     output available: bool;
     
     logical action sendAvailable;
     
-    reaction (reset) -> sendAvailable {=
+    reaction (reset_state) -> sendAvailable {=
         // reset local state
         self->consItem = 0.0;
         schedule(sendAvailable, 0);
@@ -235,7 +235,7 @@ main reactor (
     runner = new BenchmarkRunner(num_iterations=numIterations);
     manager = new ManagerReactor(bufferSize=bufferSize, numProducers=numProducers, numConsumers=numConsumers);
 
-    (runner.start)+ -> manager.start, producers.reset, consumers.reset;
+    (runner.start)+ -> manager.start, producers.reset_state_state, consumers.reset_state_state;
     manager.finished -> runner.finish;
 
     reaction(startup) {=

--- a/C/Savina/src/concurrency/BoundedBuffer.lf
+++ b/C/Savina/src/concurrency/BoundedBuffer.lf
@@ -235,7 +235,7 @@ main reactor (
     runner = new BenchmarkRunner(num_iterations=numIterations);
     manager = new ManagerReactor(bufferSize=bufferSize, numProducers=numProducers, numConsumers=numConsumers);
 
-    (runner.start)+ -> manager.start, producers.reset_state_state, consumers.reset_state_state;
+    (runner.start)+ -> manager.start, producers.reset_state, consumers.reset_state;
     manager.finished -> runner.finish;
 
     reaction(startup) {=

--- a/C/Savina/src/concurrency/Dictionary.lf
+++ b/C/Savina/src/concurrency/Dictionary.lf
@@ -101,9 +101,9 @@ reactor DictionaryImpl(numWorkers: size_t(20)) {
     input[numWorkers] request: Message*;
     output[numWorkers] response: int; 
 
-    input reset:bool;
+    input reset_state:bool;
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         // in C: initialize local state
         self->dataMap = std::map<int, int>();
         self->answersToSend = std::vector<int>(self->numWorkers, -1);
@@ -213,5 +213,5 @@ reactor Worker(bank_index: size_t(0), numMessagesPerWorker: size_t(10000), write
     dict.response -> workers.dictResponse;
     workers.dictRequest -> dict.request;
     workers.finished -> manager.workerFinished;
-    (manager.doWork)+ -> workers.doWork, dict.reset;
+    (manager.doWork)+ -> workers.doWork, dict.reset_state;
 }

--- a/C/Savina/src/concurrency/LogisticMap.lf
+++ b/C/Savina/src/concurrency/LogisticMap.lf
@@ -46,14 +46,14 @@ reactor SeriesWorker(bank_index: size_t(0), termIncrement: double(0.0025), start
     
     state curTerm: double;
     
-    input reset:bool;
+    input reset_state:bool;
     input nextTerm: int;
     input getTerm: int;
     output term: double;
     
     computer = new RateComputer(bank_index=bank_index, startRate=startRate, rateIncrement=rateIncrement);
 
-    reaction (reset) {=
+    reaction (reset_state) {=
         // initialize local state
         self->curTerm = self->bank_index * self->termIncrement;   
     =}
@@ -122,7 +122,7 @@ main reactor (numIterations: size_t(12), numTerms: size_t(25000), startRate: dou
 
     seriesWorkers = new[numSeries] SeriesWorker(startRate=startRate, rateIncrement=0.0025, termIncrement=0.0025);
 
-    (runner.start)+ -> manager.start, seriesWorkers.reset;
+    (runner.start)+ -> manager.start, seriesWorkers.reset_state;
     manager.finished -> runner.finish;
     
     (manager.nextTerm)+ -> seriesWorkers.nextTerm;

--- a/C/Savina/src/concurrency/SleepingBarber.lf
+++ b/C/Savina/src/concurrency/SleepingBarber.lf
@@ -175,7 +175,7 @@ reactor WaitingRoom(capacity:size_t(1000), numCustomers:size_t(2000)) {
         #include "deque.c"
     =}
 
-    input reset:bool;
+    input reset_state:bool;
     input receiveCustomer: size_t;
     
     output[numCustomers] full: bool;
@@ -188,7 +188,7 @@ reactor WaitingRoom(capacity:size_t(1000), numCustomers:size_t(2000)) {
     state queue: deque_t;
     state barberAsleep: bool(true);
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         self->barberAsleep = true;
     =}
     
@@ -281,7 +281,7 @@ reactor Barber(
                                      // in arbitrary units.
     numCustomers:size_t(2000)
 ) {
-    input reset: bool;
+    input reset_state: bool;
     input enter: size_t;
     input sleep: bool;
         
@@ -293,7 +293,7 @@ reactor Barber(
     
     state random: PseudoRandom;
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         // Use the same seed as in the C++ and Akka benchmarks.
         self->random.mValue = 74755;
     =}
@@ -346,7 +346,7 @@ main reactor (
     barber = new Barber(averageHaircutRate=averageHaircutRate, numCustomers=numHaircuts)
     customers = new[numHaircuts] Customer();
         
-    (runner.start)+ -> factory.start, barber.reset, room.reset;
+    (runner.start)+ -> factory.start, barber.reset_state, room.reset_state;
     factory.finished -> runner.finish;
 
     factory.sendCustomer -> room.receiveCustomer;

--- a/Cpp/Savina/src/concurrency/Banking.lf
+++ b/Cpp/Savina/src/concurrency/Banking.lf
@@ -100,10 +100,10 @@ reactor Teller(numAccounts:size_t(1000), numBankings:size_t(50000)) {
     reaction(start) -> reset_state, next {=
         reactor::log::Info() << "Teller: Start a new iteration";
         
-        // reset_state local state
+        // reset local state
         randomGen = PseudoRandom(123456);
 
-        // reset_state all accounts
+        // reset all accounts
         for (auto& r : reset_state)
             r.set();
 

--- a/Cpp/Savina/src/concurrency/Banking.lf
+++ b/Cpp/Savina/src/concurrency/Banking.lf
@@ -73,7 +73,7 @@ reactor Teller(numAccounts:size_t(1000), numBankings:size_t(50000)) {
     input start:void;
     output finished:void;
     
-    output[numAccounts] reset: void;
+    output[numAccounts] reset_state: void;
     output[numAccounts] credit: CreditMessage;
     
     logical action next: void;
@@ -97,14 +97,14 @@ reactor Teller(numAccounts:size_t(1000), numBankings:size_t(50000)) {
         }
     =}
     
-    reaction(start) -> reset, next {=
+    reaction(start) -> reset_state, next {=
         reactor::log::Info() << "Teller: Start a new iteration";
         
-        // reset local state
+        // reset_state local state
         randomGen = PseudoRandom(123456);
 
-        // reset all accounts
-        for (auto& r : reset)
+        // reset_state all accounts
+        for (auto& r : reset_state)
             r.set();
 
         generateWork();
@@ -138,13 +138,13 @@ reactor Teller(numAccounts:size_t(1000), numBankings:size_t(50000)) {
 reactor Account(bank_index:size_t(0), numAccounts:size_t(1000), initialBalance:double(0.0)) {
     state balance: double{0.0};
     
-    input reset: void; 
+    input reset_state: void; 
     input inCredit: CreditMessage;
    
     input[numAccounts] inDebit: double; 
     output[numAccounts] outDebit: double;
        
-    reaction (reset) {=
+    reaction (reset_state) {=
         balance = initialBalance;
     =}
     
@@ -189,6 +189,6 @@ main reactor (numIterations:size_t(12), numTransactions:size_t(50000), numAccoun
     =}
     
     teller.credit -> accounts.inCredit;
-    teller.reset -> accounts.reset;
+    teller.reset_state -> accounts.reset_state;
     accounts.outDebit -> interleaved(accounts.inDebit);
 }

--- a/Cpp/Savina/src/concurrency/BoundedBuffer.lf
+++ b/Cpp/Savina/src/concurrency/BoundedBuffer.lf
@@ -141,10 +141,10 @@ reactor ProducerReactor(bank_index: size_t{0}, numItemsToProduce: size_t{1000}, 
     input produce: void;
     output data: double
     
-    input reset: void;
+    input reset_state: void;
     output finished: void;
     
-    reaction (reset) {=   
+    reaction (reset_state) {=   
         // reset local state
         prodItem = 0.0;
         itemsProduced = 0;
@@ -168,14 +168,14 @@ reactor ConsumerReactor(bank_index: size_t{0}, consCost: size_t{25}) {
     
     state consItem: double{0.0};
     
-    input reset: void;
+    input reset_state: void;
     
     input data: double;
     output available: void;
     
     logical action sendAvailable;
     
-    reaction (reset) -> sendAvailable {=
+    reaction (reset_state) -> sendAvailable {=
         // reset local state
         consItem = 0.0;
         sendAvailable.schedule();
@@ -206,7 +206,7 @@ main reactor (
     manager = new ManagerReactor(bufferSize=bufferSize, numProducers=numProducers, numConsumers=numConsumers);
     runner = new BenchmarkRunner(numIterations=numIterations);
     
-    (runner.start)+ -> manager.start, producers.reset, consumers.reset;
+    (runner.start)+ -> manager.start, producers.reset_state, consumers.reset_state;
     manager.finished -> runner.finished;
     
     reaction(startup){=

--- a/Cpp/Savina/src/concurrency/BoundedBuffer2.lf
+++ b/Cpp/Savina/src/concurrency/BoundedBuffer2.lf
@@ -98,11 +98,11 @@ reactor Consumer(bank_index: size_t{0}, consCost: size_t{25}) {
     
     state consItem: double{0.0};
     
-    input reset: void;
+    input reset_state: void;
     
     input data: double;
     
-    reaction (reset) {=
+    reaction (reset_state) {=
         // reset local state
         consItem = 0.0;
     =}
@@ -127,7 +127,7 @@ main reactor (
     producers = new[numProducers] Producer(numItemsToProduce=numItemsPerProducer, prodCost=prodCost);
     consumers = new[numConsumers] Consumer(consCost=consCost);
     
-    (runner.start)+ -> producers.start, consumers.reset;
+    (runner.start)+ -> producers.start, consumers.reset_state;
     producers.data -> consumers.data;
     
     reaction(startup){=

--- a/Cpp/Savina/src/concurrency/Dictionary.lf
+++ b/Cpp/Savina/src/concurrency/Dictionary.lf
@@ -93,9 +93,9 @@ reactor DictionaryImpl(numWorkers: size_t{20}) {
 
     input[numWorkers] request: Message;
     output[numWorkers] response: int; 
-    input reset: void;
+    input reset_state: void;
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         // reset local state
         dataMap.clear();
         answersToSend.clear();
@@ -198,5 +198,5 @@ main reactor (numIterations: size_t{12}, numMessagesPerWorker: size_t{10000}, wr
     dict.response -> workers.dictResponse;
     workers.dictRequest -> dict.request;
     workers.finished -> manager.workerFinished;
-    (manager.doWork)+ -> workers.doWork, dict.reset;
+    (manager.doWork)+ -> workers.doWork, dict.reset_state;
 }

--- a/Cpp/Savina/src/concurrency/LogisticMap.lf
+++ b/Cpp/Savina/src/concurrency/LogisticMap.lf
@@ -48,14 +48,14 @@ reactor SeriesWorker(bank_index: size_t{0}, termIncrement: double{0.0025}, start
     
     state curTerm: double;
     
-    input reset: void;
+    input reset_state: void;
     input nextTerm: void;
     input getTerm: void;
     output term: double;
     
     computer = new RateComputer(bank_index=bank_index, startRate=startRate, rateIncrement=rateIncrement);
 
-    reaction (reset) {=
+    reaction (reset_state) {=
         //reset local state
         curTerm = bank_index * termIncrement;   
     =}
@@ -124,7 +124,7 @@ main reactor (numIterations: size_t{12}, numTerms: size_t{25000}, startRate: dou
     
     seriesWorkers = new[numSeries] SeriesWorker(startRate=startRate, rateIncrement=0.0025, termIncrement=0.0025);
     
-    (runner.start)+ -> manager.start, seriesWorkers.reset;
+    (runner.start)+ -> manager.start, seriesWorkers.reset_state;
     manager.finished -> runner.finished;
     
     (manager.nextTerm)+ -> seriesWorkers.nextTerm;

--- a/Cpp/Savina/src/concurrency/SleepingBarber.lf
+++ b/Cpp/Savina/src/concurrency/SleepingBarber.lf
@@ -151,7 +151,7 @@ reactor CustomerFactory(numCustomers:size_t(2000), averageProductionRate:size_t(
 }
 
 reactor WaitingRoom(capacity:size_t(1000), numCustomers:size_t(2000)) {
-    input reset: void;
+    input reset_state: void;
     
     input receiveCustomer: size_t;
     
@@ -165,7 +165,7 @@ reactor WaitingRoom(capacity:size_t(1000), numCustomers:size_t(2000)) {
     state queue: std::deque<size_t>{};
     state barberAsleep: bool{true};
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         barberAsleep = true;
     =}
     
@@ -226,7 +226,7 @@ reactor Customer(bank_index:size_t(0)) {
 }
 
 reactor Barber(averageHaircutRate:size_t(1000), numCustomers:size_t(2000)) {
-    input reset: void;
+    input reset_state: void;
     input enter: size_t;
     input wait: void;
         
@@ -238,7 +238,7 @@ reactor Barber(averageHaircutRate:size_t(1000), numCustomers:size_t(2000)) {
     
     state random: PseudoRandom;
     
-    reaction (reset) {=
+    reaction (reset_state) {=
         random = PseudoRandom();
     =}
       
@@ -282,7 +282,7 @@ main reactor (numIterations:size_t(12), waitingRoomSize:size_t(1000), averagePro
         printSystemInfo();
     =}
     
-    (runner.start)+ -> factory.start, barber.reset, room.reset;
+    (runner.start)+ -> factory.start, barber.reset_state, room.reset_state;
     factory.finished -> runner.finished;
     
     factory.sendCustomer -> room.receiveCustomer;

--- a/Rust/Savina/src/concurrency/Dictionary.lf
+++ b/Rust/Savina/src/concurrency/Dictionary.lf
@@ -64,7 +64,7 @@ reactor DictionaryImpl(num_workers: usize(20)) {
 
     state num_requests_served: u32(0);
 
-    input reset: unit;
+    input reset_state: unit;
 
     // Having the action in the dictionary is faster... (this is a c++ comment)
     logical action send_answers: unit;
@@ -72,7 +72,7 @@ reactor DictionaryImpl(num_workers: usize(20)) {
     input[num_workers] request: Message;
     output[num_workers] response: u32;
 
-    reaction(reset) {=
+    reaction(reset_state) {=
         // reset local state
         self.data_map.clear();
         for i in &mut self.answers_to_send {
@@ -185,7 +185,7 @@ main reactor (num_messages_per_worker: usize(10000),
     dict = new DictionaryImpl(num_workers=num_workers);
     workers = new[num_workers] Worker(num_messages_per_worker=num_messages_per_worker, write_percentage=write_percentage);
 
-    (runner.start)+ -> workers.start, dict.reset;
+    (runner.start)+ -> workers.start, dict.reset_state;
     workers.done -> manager.worker_finished;
     manager.finished -> runner.finished;
 

--- a/Rust/Savina/src/concurrency/LogisticMap.lf
+++ b/Rust/Savina/src/concurrency/LogisticMap.lf
@@ -43,14 +43,14 @@ reactor SeriesWorker(bank_index: usize(0), termIncrement: f64(0.0025), startRate
     
     state cur_term: f64;
     
-    input reset: unit;
+    input reset_state: unit;
     input nextTerm: unit;
     input getTerm: unit;
     output term: f64;
     
     computer = new RateComputer(bank_index=bank_index, startRate=startRate, rateIncrement=rateIncrement);
 
-    reaction (reset) {=
+    reaction (reset_state) {=
         //reset local state
         let bank_index_f = self.bank_index as f64;
         self.cur_term = bank_index_f * self.term_increment;   
@@ -132,7 +132,7 @@ main reactor (numIterations: usize(12), numTerms: usize(25000), startRate: f64(3
     
     seriesWorkers = new[numSeries] SeriesWorker(startRate=startRate, rateIncrement=0.0025, termIncrement=0.0025);
     
-    (runner.start)+ -> manager.start, seriesWorkers.reset;
+    (runner.start)+ -> manager.start, seriesWorkers.reset_state;
     manager.finished -> runner.finished;
     
     (manager.nextTerm)+ -> seriesWorkers.nextTerm;

--- a/Rust/Savina/src/concurrency/SleepingBarber.lf
+++ b/Rust/Savina/src/concurrency/SleepingBarber.lf
@@ -146,7 +146,7 @@ reactor CustomerFactory(numCustomers:usize(2000), averageProductionRate:usize(10
 reactor WaitingRoom(capacity:usize(1000), numCustomers:usize(2000)) {
     state capacity(capacity);
     
-    input reset: unit;
+    input reset_state: unit;
     
     input receiveCustomer: usize;
     
@@ -164,7 +164,7 @@ reactor WaitingRoom(capacity:usize(1000), numCustomers:usize(2000)) {
         use std::collections::VecDeque;
     =}
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         self.barberAsleep = true;
     =} 
     
@@ -228,7 +228,7 @@ reactor Customer(bank_index:usize(0)) {
 reactor Barber(averageHaircutRate:usize(1000), numCustomers:usize(2000)) {
     state average_haircut_rate(averageHaircutRate);
     
-    input reset: unit;
+    input reset_state: unit;
     input enter: usize;
     input wait: unit;
         
@@ -240,7 +240,7 @@ reactor Barber(averageHaircutRate:usize(1000), numCustomers:usize(2000)) {
     
     state random: PseudoRandomGenerator;
     
-    reaction(reset) {=
+    reaction(reset_state) {=
         self.random = PseudoRandomGenerator::default();
     =}    
     
@@ -320,7 +320,7 @@ main reactor (numIterations:usize(12), waitingRoomSize:usize(1000), averageProdu
         print_system_info();
     =}
     
-    (runner.start)+ -> factory.start, barber.reset, room.reset;
+    (runner.start)+ -> factory.start, barber.reset_state, room.reset_state;
     factory.finished -> runner.finished;
     
     factory.sendCustomer -> room.receiveCustomer;


### PR DESCRIPTION
Required by [LF PR #1169](https://github.com/lf-lang/lingua-franca/pull/1169)