### PR TITLE
Fix models that use names now blocked by modal model keywords (addendum)

### DIFF
--- a/Rust/Savina/src/concurrency/Banking.lf
+++ b/Rust/Savina/src/concurrency/Banking.lf
@@ -72,19 +72,19 @@ reactor Teller(numAccounts:usize(1000), numBankings:usize(50000)) {
     input start:unit;
     output finished:unit;
 
-    output[numAccounts] reset: unit;
+    output[numAccounts] reset_state: unit;
     output[numAccounts] credit: CreditMessage;
 
     logical action next;
 
-    reaction(start) -> reset, next {=
+    reaction(start) -> reset_state, next {=
         info!("Teller: Start a new iteration");
 
         // reset local state
         self.randomGen.reseed(123456);
 
         // reset all accounts
-        for r in reset {
+        for r in reset_state {
             ctx.set(r, ());
         }
 
@@ -140,7 +140,7 @@ reactor Account(bank_index:usize(0), numAccounts:usize(1000), initialBalance:f64
 
     state balance: f64(0.0);
 
-    input reset: unit;
+    input reset_state: unit;
     input inCredit: CreditMessage;
 
     input[numAccounts] inDebit: f64;
@@ -150,7 +150,7 @@ reactor Account(bank_index:usize(0), numAccounts:usize(1000), initialBalance:f64
         use crate::reactors::teller::CreditMessage;
     =}
 
-    reaction (reset) {=
+    reaction (reset_state) {=
         self.balance = self.initial_balance;
     =}
 
@@ -206,7 +206,7 @@ main reactor (numIterations:usize(12), numTransactions:usize(50000), numAccounts
     teller.finished -> runner.finished;
 
     teller.credit -> accounts.inCredit;
-    teller.reset -> accounts.reset;
+    teller.reset_state -> accounts.reset_state;
     accounts.outDebit -> interleaved(accounts.inDebit);
 
     preamble {=

--- a/Rust/Savina/src/concurrency/BoundedBuffer.lf
+++ b/Rust/Savina/src/concurrency/BoundedBuffer.lf
@@ -104,10 +104,10 @@ reactor ProducerReactor(bank_index: usize(0), numItemsToProduce: usize(1000), pr
     input produce: unit;
     output data: f64;
 
-    input reset: unit;
+    input reset_state: unit;
     output finished: unit;
 
-    reaction(reset) {=
+    reaction(reset_state) {=
         // reset local state
         self.prod_item = 0.0;
         self.items_produced = 0;
@@ -154,14 +154,14 @@ reactor ConsumerReactor(bank_index: usize(0), consCost: usize(25)) {
 
     state cons_item: f64(0.0);
 
-    input reset: unit;
+    input reset_state: unit;
 
     input data: f64;
     output available: unit;
 
     logical action sendAvailable;
 
-    reaction (reset) -> sendAvailable {=
+    reaction (reset_state) -> sendAvailable {=
         // reset local state
         self.cons_item = 0.0;
         ctx.schedule(sendAvailable, Asap);
@@ -205,7 +205,7 @@ main reactor (
     manager = new ManagerReactor(bufferSize=bufferSize, numProducers=numProducers, numConsumers=numConsumers);
     runner = new BenchmarkRunner(num_iterations=numIterations);
 
-    (runner.start)+ -> manager.start, producers.reset, consumers.reset;
+    (runner.start)+ -> manager.start, producers.reset_state, consumers.reset_state;
     manager.finished -> runner.finished;
 
     reaction(startup){=


### PR DESCRIPTION
Required by [LF PR #1169](https://github.com/lf-lang/lingua-franca/pull/1169)

Fixes models added after PR #15