### PR TITLE
Utilize the BenchmarkRunner reactor & Add 'lf-ts' section in runner configuration

### DIFF
--- a/TS/Savina/src/micro/Big.lf
+++ b/TS/Savina/src/micro/Big.lf
@@ -8,9 +8,11 @@ target TypeScript {
     fast: true
 };
 
-main reactor Big(limit:number(25000)) {
-    
-    state startTime:time;
+import BenchmarkRunner from "../BenchmarkRunner.lf";
+
+main reactor Big(numIterations:number(12), limit:number(25000)) {
+
+    runner = new BenchmarkRunner(numIterations = numIterations);
     
     s = new Sink();
     
@@ -19,6 +21,9 @@ main reactor Big(limit:number(25000)) {
     p3 = new PingPonger(limit = limit, index = 3);
     p4 = new PingPonger(limit = limit, index = 4);
     p5 = new PingPonger(limit = limit, index = 5);
+
+    (runner.start)+ -> p1.start, p2.start, p3.start, p4.start, p5.start;
+    s.stopTimer -> runner.finish;
     
     p1.done -> s.done1;
     p2.done -> s.done2;
@@ -75,30 +80,14 @@ main reactor Big(limit:number(25000)) {
     p5.respond2 -> p2.ack5;
     p5.respond3 -> p3.ack5;
     p5.respond4 -> p4.ack5;
-    
-    reaction(startup) -> p1.start, p2.start, p3.start, p4.start, p5.start {=
-        startTime = util.getCurrentPhysicalTime();
-        p1.start = null;
-        p2.start = null;
-        p3.start = null;
-        p4.start = null;
-        p5.start = null;   
-    =}
-    
-    reaction(s.stopTimer) {=
-        if (startTime) {
-            let elapsedTime = util.getCurrentPhysicalTime().subtract(startTime);
-            console.log("Elapsed time: " + elapsedTime);
-            util.requestStop();
-        }
-    =}
+
 }
 
 
 // Index is the number of this ping ponger and must be set
 // to x with 1 <= x <= numberOfActors, when the instance is created.
 reactor PingPonger(limit:number(25000), index:number(-1), numberOfActors:number(5)) {
-    input start:null;
+    input start:boolean;
     output done:null;
     output send1:string;
     output send2:string;
@@ -134,27 +123,27 @@ reactor PingPonger(limit:number(25000), index:number(-1), numberOfActors:number(
         switch (sendIndex) {
             case 1: {
                 send1 = "ping";
-//                console.log(`In index: ${index}, pinging: 1 `);
+            //    console.log(`In index: ${index}, pinging: 1 `);
                 break;
             }
             case 2: {
                 send2 = "ping";
-//                console.log(`In index: ${index}, pinging: 2 `);
+            //    console.log(`In index: ${index}, pinging: 2 `);
                 break;
             }
             case 3: {
                 send3 = "ping";
-//                console.log(`In index: ${index}, pinging: 3 `);
+            //    console.log(`In index: ${index}, pinging: 3 `);
                 break;
             }
             case 4: {
                 send4 = "ping";
-//                console.log(`In index: ${index}, pinging: 4 `);
+            //    console.log(`In index: ${index}, pinging: 4 `);
                 break;
             }
             case 5: {
                 send5 = "ping";
-//                console.log(`In index: ${index}, pinging: 5 `);
+            //    console.log(`In index: ${index}, pinging: 5 `);
                 break;
             }
         }
@@ -162,33 +151,34 @@ reactor PingPonger(limit:number(25000), index:number(-1), numberOfActors:number(
     
     reaction (receive1) -> respond1 {=
         respond1 = "pong";
-//        console.log(`In index: ${index}, ponging: 1 `);
+    //    console.log(`In index: ${index}, ponging: 1 `);
     =}
     
     reaction (receive2) -> respond2 {=
         respond2 = "pong";
-//        console.log(`In index: ${index}, ponging: 2 `);
+    //    console.log(`In index: ${index}, ponging: 2 `);
     =}
     
     reaction (receive3) -> respond3 {=
         respond3 = "pong";
-//        console.log(`In index: ${index}, ponging: 3 `);
+    //    console.log(`In index: ${index}, ponging: 3 `);
     =}
     
     reaction (receive4) -> respond4 {=
         respond4 = "pong";
-//        console.log(`In index: ${index}, ponging: 4 `);
+    //    console.log(`In index: ${index}, ponging: 4 `);
     =}
     
     reaction (receive5) -> respond5 {=
         respond5 = "pong";
-//        console.log(`In index: ${index}, ponging: 5 `);
+    //    console.log(`In index: ${index}, ponging: 5 `);
     =}
     
     reaction (start, ack1, ack2, ack3, ack4, ack5) -> nextServe, done {=
         remainingServes--;
-//        console.log(`Got ack in index: ${index}, remaining serves: ${remainingServes} `);
+    //    console.log(`Got ack in index: ${index}, remaining serves: ${remainingServes} `);
         if (remainingServes == 0) {
+            remainingServes = limit;
             done = null;
         } else {
             actions.nextServe.schedule(0, null);
@@ -203,37 +193,43 @@ reactor Sink(numberOfActors:number(5)) {
     input done3:null;
     input done4:null;
     input done5:null;
-    output stopTimer:null;
+    output stopTimer:boolean;
     state count:number(0);
     
     reaction(done1) -> stopTimer {=
         count++;
         if (count == numberOfActors - 1) {
-            stopTimer = null;
+            count = 0;
+            stopTimer = true;
         }
     =}
     reaction(done2) -> stopTimer {=
         count++;
         if (count == numberOfActors - 1) {
-            stopTimer = null;
+            count = 0;
+            stopTimer = true;
         }
     =}
     reaction(done3) -> stopTimer {=
         count++;
         if (count == numberOfActors - 1) {
-            stopTimer = null;
+            count = 0;
+            stopTimer = true;
         }
     =}
     reaction(done4) -> stopTimer {=
         count++;
         if (count == numberOfActors - 1) {
-            stopTimer = null;
+            count = 0;
+            stopTimer = true;
         }
     =}
     reaction(done5) -> stopTimer {=
         count++;
         if (count == numberOfActors - 1) {
-            stopTimer = null;
+            count = 0;
+            stopTimer = true;
         }
     =}
+
 }

--- a/TS/Savina/src/micro/Chameneos.lf
+++ b/TS/Savina/src/micro/Chameneos.lf
@@ -10,11 +10,13 @@ target TypeScript {
     fast: true
 };
 
-main reactor Chameneos(limit:number(25000)) {
+import BenchmarkRunner from "../BenchmarkRunner.lf";
+
+main reactor Chameneos(numIterations:number(12), limit:number(25000)) {
     
 // Conversions for updateColor from https://wiki.haskell.org/Shootout/Chameneos
    preamble {=
-        enum Color {RED, YELLOW, BLUE};
+        enum Color {RED, YELLOW, BLUE}
         function updateColor(a : Color, b : Color) : Color {
             // console.log("Got a: " + a + ", b: " + b);
             if (a == Color.RED && b == Color.RED) return Color.RED;
@@ -29,16 +31,12 @@ main reactor Chameneos(limit:number(25000)) {
             return null as never;
         }
     =}
-   state startTime:time;
-   reaction (startup) -> m.start {=
-        m.start = true;
-        startTime = util.getCurrentPhysicalTime();
-    =}
-   reaction (m.done) {=
-        let elapsedTime = util.getCurrentPhysicalTime().subtract(startTime as TimeValue);
-        console.log("Elapsed time: " + elapsedTime);
-        util.requestStop();
-   =}
+
+   runner = new BenchmarkRunner(numIterations=numIterations);
+
+   runner.start -> m.start;
+   m.done -> runner.finish;
+
    m = new Mall(limit = limit);
    
    l0 = new Lizard(initialColor = {= Color.RED =});
@@ -104,6 +102,21 @@ main reactor Chameneos(limit:number(25000)) {
 }
 
 reactor Mall(limit:number(25000)) {
+    
+    preamble {=
+        function permuteLizards(freeLizards: Array<number>): Array<number> {
+            const permutedLizards = new Array<number>();
+            
+            while (freeLizards.length > 0) {
+                const index = Math.floor(Math.random()*freeLizards.length);
+                const nextLizard = freeLizards[index];
+                freeLizards.splice(index, 1);
+                permutedLizards.push(nextLizard);
+            }
+            return permutedLizards;
+        }
+    =}
+
     input start:boolean;
     input ready0:boolean;
     input ready1:boolean;
@@ -123,19 +136,8 @@ reactor Mall(limit:number(25000)) {
     // Then repeat for every other available pair of lizards.
     reaction (ready0, ready1, ready2, ready3, ready4) -> l0instruction, l1instruction, l2instruction, l3instruction, l4instruction, done {=
         
-        function permuteLizards(freeLizards: Array<number>): Array<number> {
-            let permutedLizards = new Array<number>();
-            
-            while (freeLizards.length > 0) {
-                let index = Math.floor(Math.random()*freeLizards.length);
-                let nextLizard = freeLizards[index];
-                freeLizards.splice(index, 1);
-                permutedLizards.push(nextLizard);
-            }
-            return permutedLizards;
-        }
-        
         if (count == limit - 1) {
+            count = 0;
             done = true;
         } else {
             // Randomly permute the ready lizards, then assign pairs as friends

--- a/TS/Savina/src/micro/CountingActor.lf
+++ b/TS/Savina/src/micro/CountingActor.lf
@@ -1,6 +1,9 @@
 target TypeScript{
     fast: true
 };
+
+import BenchmarkRunner from "../BenchmarkRunner.lf";
+
 reactor Counter(limit:number(25000)) {
     input receive:number;
     output done:boolean;
@@ -8,6 +11,7 @@ reactor Counter(limit:number(25000)) {
     reaction (receive) -> done {=
         count++;
         if (count == limit -1) {
+            count = 0;
             done = true;
         }
     =}
@@ -21,22 +25,15 @@ reactor Sender {
         send = 1;
     =}
 }
-main reactor CountingActor(limit:number(25000)) {
-    
-    state startTime:time;
+main reactor CountingActor(numIterations:number(12), limit:number(25000)) {
+
+    runner = new BenchmarkRunner(numIterations = numIterations);
     
     s = new Sender();
     c = new Counter(limit = limit);
+
+    runner.start -> s.start;
+    c.done -> runner.finish;
     
     s.send -> c.receive;
-    
-    reaction (startup) -> s.start {=
-        s.start = true;
-        startTime = util.getCurrentPhysicalTime();
-    =}
-    reaction (c.done) {=
-        let elapsedTime = util.getCurrentPhysicalTime().subtract(startTime as TimeValue);
-        console.log("Elapsed time: " + elapsedTime);
-        util.requestStop();
-    =}
 }

--- a/TS/Savina/src/micro/ThreadRing.lf
+++ b/TS/Savina/src/micro/ThreadRing.lf
@@ -2,6 +2,9 @@
 target TypeScript {
     fast: true
 };
+
+import BenchmarkRunner from "../BenchmarkRunner.lf";
+
 // To prevent a cycle, one node has to schedule an action upon receiving an input
 reactor StartNode(limit:number(25000)) {
     input receive:number;
@@ -44,13 +47,13 @@ reactor Node {
     =}
 }
 
-main reactor ThreadRing(limit:number(25000)) {
-    state startTime:time;
+main reactor ThreadRing(numIterations:number(12), limit:number(25000)) {
     logical action end;
-    reaction (startup) -> n1.start {=
-        startTime = util.getCurrentPhysicalTime();
-        n1.start = true;
-    =}
+
+    runner = new BenchmarkRunner(numIterations=numIterations);
+
+    runner.start -> n1.start;
+
     reaction (n1.done) -> end {=
         actions.end.schedule(0, null);
     =}
@@ -66,13 +69,10 @@ main reactor ThreadRing(limit:number(25000)) {
     reaction (n5.done) -> end {=
         actions.end.schedule(0, null);
     =}
-    reaction (end) {=
-        if (startTime) {
-            let elapsedTime = util.getCurrentPhysicalTime().subtract(startTime);
-            console.log("Elapsed time: " + elapsedTime);
-            util.requestStop();
-        }
+    reaction (end) -> runner.finish {=
+        runner.finish = true;
     =}  
+
     n1 = new StartNode(limit = limit);
     n2 = new Node();
     n3 = new Node();

--- a/runner/conf/benchmark/savina_micro_big.yaml
+++ b/runner/conf/benchmark/savina_micro_big.yaml
@@ -48,3 +48,12 @@ targets:
     run_args:
       messages: ["--main-num-pings-per-reactor", "<value>"]
       actors: ["--main-num-reactors", "<value>"]
+  lf-ts:
+    copy_sources:
+      - "${bench_path}/TS/Savina/src/BenchmarkRunner.lf"
+      - "${bench_path}/TS/Savina/src/micro"
+    lf_file: "micro/Big.lf"
+    script: "src-gen/micro/Big/dist/Big.js"
+    gen_args:
+      messages: ["-D", "numPingsPerReactor=<value>"]
+      actors: ["-D", "numReactors=<value>"]

--- a/runner/conf/benchmark/savina_micro_chameneos.yaml
+++ b/runner/conf/benchmark/savina_micro_chameneos.yaml
@@ -45,3 +45,11 @@ targets:
     run_args:
       meetings: ["--main-num-meetings", "<value>"]
       chameneos: ["--main-num-chameneos", "<value>"]
+  lf-ts:
+    copy_sources:
+      - "${bench_path}/TS/Savina/src/BenchmarkRunner.lf"
+      - "${bench_path}/TS/Savina/src/micro"
+    lf_file: "micro/Chameneos.lf"
+    script: "src-gen/micro/Chameneos/dist/Chameneos.js"
+    gen_args:
+      meetings: ["-D", "limit=<value>"]

--- a/runner/conf/benchmark/savina_micro_count.yaml
+++ b/runner/conf/benchmark/savina_micro_count.yaml
@@ -39,3 +39,11 @@ targets:
     binary: "counting"
     run_args:
       messages: ["--main-count-to", "<value>"]
+  lf-ts:
+    copy_sources:
+      - "${bench_path}/TS/Savina/src/BenchmarkRunner.lf"
+      - "${bench_path}/TS/Savina/src/micro"
+    lf_file: "micro/CountingActor.lf"
+    script: "src-gen/micro/CountingActor/dist/CountingActor.js"
+    gen_args:
+      messages: ["-D", "limit=<value>"]

--- a/runner/conf/benchmark/savina_micro_threadring.yaml
+++ b/runner/conf/benchmark/savina_micro_threadring.yaml
@@ -44,4 +44,13 @@ targets:
     binary: "thread_ring"
     run_args:
       actors: ["--main-num-reactors", "<value>"]
-      pings: ["--main-num-pings", "<value>"]
+      pings: ["--main-num-pings", "<value>"]  
+  lf-ts:
+    copy_sources:
+      - "${bench_path}/TS/Savina/src/BenchmarkRunner.lf"
+      - "${bench_path}/TS/Savina/src/micro"
+    lf_file: "micro/ThreadRing.lf"
+    script: "src-gen/micro/ThreadRing/dist/ThreadRing.js"
+    gen_args:
+      actors: ["-D", "emty=<value>"]
+      pings: ["-D", "limit=<value>"]

--- a/runner/conf/benchmark/savina_micro_threadring.yaml
+++ b/runner/conf/benchmark/savina_micro_threadring.yaml
@@ -52,5 +52,4 @@ targets:
     lf_file: "micro/ThreadRing.lf"
     script: "src-gen/micro/ThreadRing/dist/ThreadRing.js"
     gen_args:
-      actors: ["-D", "emty=<value>"]
       pings: ["-D", "limit=<value>"]


### PR DESCRIPTION
In issue https://github.com/lf-lang/benchmarks-lingua-franca/issues/23,
I did the second and third tasks for all implemented TS benchmarks except for ActorCreation and ForkJoin benchmarks.


(I don't know the difference between ForkJoin and Throughput benchmarks.
And there is some issue that ActorCreation's mutation finishes part. The created reactor cannot adjust the first reactor's finish outport. The necessary of this action is because, in the main reactor, we should connect the first reactor and runner)