### PR TITLE
Use new API method for getting all present ports on a multiport to optimize for sparse multiports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
     with:
       target: 'Cpp'
+      compiler-ref: 'multiport-cpp'
   rs-benchmark-tests:
     uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
     with:

--- a/Cpp/Savina/src/concurrency/Banking.lf
+++ b/Cpp/Savina/src/concurrency/Banking.lf
@@ -159,7 +159,7 @@ reactor Account(bank_index:size_t(0), numAccounts:size_t(1000), initialBalance:d
     =}
     
     reaction (inDebit) {=
-        for (auto i: inDebit.active_ports_indices()) {
+        for (auto i: inDebit.get_present_port_indices()) {
             double amount = *(inDebit[i].get());
             // increase the balance
             balance += amount;

--- a/Cpp/Savina/src/concurrency/Banking.lf
+++ b/Cpp/Savina/src/concurrency/Banking.lf
@@ -159,13 +159,11 @@ reactor Account(bank_index:size_t(0), numAccounts:size_t(1000), initialBalance:d
     =}
     
     reaction (inDebit) {=
-        for (auto& port : inDebit) {
-            if (port.is_present()) {
-                double amount = *port.get();
-                // increase the balance
-                balance += amount;
-                reactor::log::Info() << "Account " << bank_index << " received " << amount;                
-            }
+        for (auto i: inDebit.active_ports_indices()) {
+            double amount = *(inDebit[i].get());
+            // increase the balance
+            balance += amount;
+            reactor::log::Info() << "Account " << bank_index << " received " << amount; 
         }
     =}
 }

--- a/Cpp/Savina/src/concurrency/BoundedBuffer.lf
+++ b/Cpp/Savina/src/concurrency/BoundedBuffer.lf
@@ -114,13 +114,13 @@ reactor ManagerReactor(bufferSize: size_t{50}, numProducers: size_t{40}, numCons
     =}
         
     reaction(producerData) {=
-        for (auto i: producerData.active_ports_indices()) {
+        for (auto i: producerData.get_present_port_indices()) {
             pendingData.push_back(*producerData[i].get());
         }
     =}
     
     reaction(producerFinished) {=
-        for (auto i: producerFinished.active_ports_indices()) {
+        for (auto i: producerFinished.get_present_port_indices()) {
             numTerminatedProducers++;
             producerTerminated[i] = true;
             reactor::log::Info() << "Prdoucer " << i << " finished";                

--- a/Cpp/Savina/src/concurrency/BoundedBuffer.lf
+++ b/Cpp/Savina/src/concurrency/BoundedBuffer.lf
@@ -114,20 +114,16 @@ reactor ManagerReactor(bufferSize: size_t{50}, numProducers: size_t{40}, numCons
     =}
         
     reaction(producerData) {=
-        for (const auto& data : producerData) {
-            if (data.is_present()) {
-                pendingData.push_back(*data.get());
-            }
+        for (auto i: producerData.active_ports_indices()) {
+            pendingData.push_back(*producerData[i].get());
         }
     =}
     
     reaction(producerFinished) {=
-        for (size_t i{0}; i < numProducers; i++) {
-            if (producerFinished[i].is_present()) {
-                numTerminatedProducers++;
-                producerTerminated[i] = true;
-                reactor::log::Info() << "Prdoucer " << i << " finished";                
-            }
+        for (auto i: producerFinished.active_ports_indices()) {
+            numTerminatedProducers++;
+            producerTerminated[i] = true;
+            reactor::log::Info() << "Prdoucer " << i << " finished";                
         }
     =}           
         

--- a/Cpp/Savina/src/concurrency/BoundedBuffer2.lf
+++ b/Cpp/Savina/src/concurrency/BoundedBuffer2.lf
@@ -140,6 +140,7 @@ main reactor (
 
     reaction (producers.finished) -> runner.finished {=
         // if one producer finished, all should have finished.
+
         for (auto& p : producers) {
             if (!p.finished.is_present()) {
                 std::cerr << "ERROR: All producers should have finished.";

--- a/Cpp/Savina/src/concurrency/Dictionary.lf
+++ b/Cpp/Savina/src/concurrency/Dictionary.lf
@@ -68,7 +68,7 @@ reactor Manager(numWorkers: size_t{20}) {
     =}
     
     reaction(workerFinished) -> finished {=
-        numWorkersTerminated += workerFinished.active_ports_indices().size();
+        numWorkersTerminated += workerFinished.get_present_port_indices().size();
 
         if(numWorkersTerminated == numWorkers) {
             reactor::log::Info() << "All " << numWorkersTerminated << " workers terminated.";
@@ -112,7 +112,7 @@ reactor DictionaryImpl(numWorkers: size_t{20}) {
     reaction(request) -> sendAnswers {=
         // The order of messages to read is relevant, it effectively
         // assigns priorities to the workers.
-        for (auto i: request.active_ports_indices()) {
+        for (auto i: request.get_present_port_indices()) {
             auto msg = request[i].get();
 
             if(msg->type == AccessType::Write) {  

--- a/Cpp/Savina/src/concurrency/Dictionary.lf
+++ b/Cpp/Savina/src/concurrency/Dictionary.lf
@@ -21,6 +21,7 @@
  * 
  * @author Christian Menard
  * @author Hannes Klein
+ * @author Tassilo Tanneberger
  */
 
 target Cpp {
@@ -67,11 +68,8 @@ reactor Manager(numWorkers: size_t{20}) {
     =}
     
     reaction(workerFinished) -> finished {=
-        for (const auto& fin : workerFinished) {
-            if (fin.is_present()) {
-                numWorkersTerminated++;
-            }
-        }
+        numWorkersTerminated += workerFinished.active_ports_indices().size();
+
         if(numWorkersTerminated == numWorkers) {
             reactor::log::Info() << "All " << numWorkersTerminated << " workers terminated.";
             finished.set();
@@ -114,26 +112,24 @@ reactor DictionaryImpl(numWorkers: size_t{20}) {
     reaction(request) -> sendAnswers {=
         // The order of messages to read is relevant, it effectively
         // assigns priorities to the workers.
-        for(size_t i{0}; i < numWorkers; i++) {
-            if(request[i].is_present()) {
-                auto msg = request[i].get();
-                
-                if(msg->type == AccessType::Write) {  
-                    dataMap.emplace(msg->key, msg->value);
-                    // Savina sends ResultMsg always independently if adding (key,value)
-                    // to the map was successful.
-                    answersToSend[i] = msg->value;
-                    reactor::log::Info() << "Worker " << i << " writes " << msg->value << " to key " << msg->key;
-                } else if(msg->type == AccessType::Read) {
-                    // Find the value. If the key is not present, return -1
-                    auto it = dataMap.find(msg->key);
-                    int value{0};
-                    if (it != dataMap.end()) {
-                        value = it->second;    
-                    }
-                    answersToSend[i] = value;
-                    reactor::log::Info() << "Worker " << i << " reads key " << msg->key << "; response is " << value;
+        for (auto i: request.active_ports_indices()) {
+            auto msg = request[i].get();
+
+            if(msg->type == AccessType::Write) {  
+                dataMap.emplace(msg->key, msg->value);
+                // Savina sends ResultMsg always independently if adding (key,value)
+                // to the map was successful.
+                answersToSend[i] = msg->value;
+                reactor::log::Info() << "Worker " << i << " writes " << msg->value << " to key " << msg->key;
+            } else if(msg->type == AccessType::Read) {
+                // Find the value. If the key is not present, return -1
+                auto it = dataMap.find(msg->key);
+                int value{0};
+                if (it != dataMap.end()) {
+                    value = it->second;    
                 }
+                answersToSend[i] = value;
+                reactor::log::Info() << "Worker " << i << " reads key " << msg->key << "; response is " << value;
             }
         }
         

--- a/Cpp/Savina/src/concurrency/Philosophers.lf
+++ b/Cpp/Savina/src/concurrency/Philosophers.lf
@@ -26,6 +26,7 @@
  * 
  * @author Hannes Klein
  * @author Christian Menard
+ * @author Tassilo Tanneberger 
  */
 
 target Cpp {
@@ -89,11 +90,9 @@ reactor Arbitrator(numPhilosophers:size_t(20)) {
     =}
     
     reaction (done) {=
-        for(size_t i{0}; i < numPhilosophers; i++) {
-            if (done[i].is_present()) {
-                forks[i] = false;
-                forks[(i + 1) % numPhilosophers] = false;
-            }
+        for (auto i: done.active_ports_indices()) {
+            forks[i] = false;
+            forks[(i + 1) % numPhilosophers] = false;
         }
     =}
     
@@ -120,14 +119,13 @@ reactor Arbitrator(numPhilosophers:size_t(20)) {
     =}
     
     reaction (finished) -> allFinished {=
-        for(const auto& f : finished) {
-            if (f.is_present()) {
-                numRetries += *f.get();
-                numFinishedPhilosophers++;
-                if(numPhilosophers == numFinishedPhilosophers) {
-                    std::cout << "Total retires: " << numRetries << '\n';
-                    allFinished.set();
-                }
+
+        for (auto i: finished.active_ports_indices()) {
+            numRetries += *finished[i].get();
+            numFinishedPhilosophers++;
+            if(numPhilosophers == numFinishedPhilosophers) {
+                std::cout << "Total retires: " << numRetries << '\n';
+                allFinished.set();
             }
         }
     =}

--- a/Cpp/Savina/src/concurrency/Philosophers.lf
+++ b/Cpp/Savina/src/concurrency/Philosophers.lf
@@ -90,7 +90,7 @@ reactor Arbitrator(numPhilosophers:size_t(20)) {
     =}
     
     reaction (done) {=
-        for (auto i: done.active_ports_indices()) {
+        for (auto i: done.get_present_port_indices()) {
             forks[i] = false;
             forks[(i + 1) % numPhilosophers] = false;
         }
@@ -120,7 +120,7 @@ reactor Arbitrator(numPhilosophers:size_t(20)) {
     
     reaction (finished) -> allFinished {=
 
-        for (auto i: finished.active_ports_indices()) {
+        for (auto i: finished.get_present_port_indices()) {
             numRetries += *finished[i].get();
             numFinishedPhilosophers++;
             if(numPhilosophers == numFinishedPhilosophers) {

--- a/Cpp/Savina/src/concurrency/SleepingBarber.lf
+++ b/Cpp/Savina/src/concurrency/SleepingBarber.lf
@@ -36,6 +36,7 @@
  * performance though.
  * 
  * @author Christian Menard
+ * @author Tassilo Tanneberger 
  * @author Hannes Klein
  */
 
@@ -124,27 +125,25 @@ reactor CustomerFactory(numCustomers:size_t(2000), averageProductionRate:size_t(
     =}
     
     reaction (customerReturned) -> sendCustomerAgain {=
-        for (size_t i{0}; i < numCustomers; i++) {
-            if (customerReturned[i].is_present()) {
-                /*
-                 * The customer returned because the waiting room is full. We
-                 * send the customer back again immediately. Due to the use of a
-                 * physical action, we always introduce a small logical delay,
-                 * which ensures that the program can move forward.
-                 */
-                sendCustomerAgain.schedule(i);                
-            }
+
+        for (auto i: customerReturned.active_ports_indices()) {
+            /*
+             * The customer returned because the waiting room is full. We
+             * send the customer back again immediately. Due to the use of a
+             * physical action, we always introduce a small logical delay,
+             * which ensures that the program can move forward.
+             */
+            sendCustomerAgain.schedule(i);                
         }
     =}
     
     reaction (customerDone) -> finished {=
-        for (size_t i{0}; i < numCustomers; i++) {
-            if (customerDone[i].is_present()) {
-                doneCustomers++;
-                if (doneCustomers == numCustomers) {
-                    std::cout << "Hair cuts given: " << doneCustomers << "; Total attempts: " << attempts << "\n";
-                    finished.set();
-                }
+
+        for (auto _: customerDone.active_ports_indices()) {
+            doneCustomers++;
+            if (doneCustomers == numCustomers) {
+                std::cout << "Hair cuts given: " << doneCustomers << "; Total attempts: " << attempts << "\n";
+                finished.set();
             }
         }
     =}

--- a/Cpp/Savina/src/concurrency/SleepingBarber.lf
+++ b/Cpp/Savina/src/concurrency/SleepingBarber.lf
@@ -126,7 +126,7 @@ reactor CustomerFactory(numCustomers:size_t(2000), averageProductionRate:size_t(
     
     reaction (customerReturned) -> sendCustomerAgain {=
 
-        for (auto i: customerReturned.active_ports_indices()) {
+        for (auto i: customerReturned.get_present_port_indices()) {
             /*
              * The customer returned because the waiting room is full. We
              * send the customer back again immediately. Due to the use of a
@@ -139,7 +139,7 @@ reactor CustomerFactory(numCustomers:size_t(2000), averageProductionRate:size_t(
     
     reaction (customerDone) -> finished {=
 
-        for (auto _: customerDone.active_ports_indices()) {
+        for (auto _: customerDone.get_present_port_indices()) {
             doneCustomers++;
             if (doneCustomers == numCustomers) {
                 std::cout << "Hair cuts given: " << doneCustomers << "; Total attempts: " << attempts << "\n";

--- a/Cpp/Savina/src/concurrency/SortedList.lf
+++ b/Cpp/Savina/src/concurrency/SortedList.lf
@@ -46,7 +46,7 @@ reactor Manager(numWorkers: size_t(20)) {
     =}
     
     reaction(workersFinished) -> finish {=
-        for (auto i: workersFinished.active_ports_indices()) {
+        for (auto i: workersFinished.get_present_port_indices()) {
             numWorkersTerminated += 1;
 
             if(numWorkersTerminated == numWorkers) {

--- a/Cpp/Savina/src/concurrency/SortedList.lf
+++ b/Cpp/Savina/src/concurrency/SortedList.lf
@@ -46,13 +46,11 @@ reactor Manager(numWorkers: size_t(20)) {
     =}
     
     reaction(workersFinished) -> finish {=
-        for(size_t i{0}; i < numWorkers; ++i) {
-            if(workersFinished[i].is_present()) {
-                numWorkersTerminated += 1;
-                
-                if(numWorkersTerminated == numWorkers) {
-                    finish.schedule();
-                }
+        for (auto i: workersFinished.active_ports_indices()) {
+            numWorkersTerminated += 1;
+
+            if(numWorkersTerminated == numWorkers) {
+                finish.schedule();
             }
         }
     =}

--- a/Cpp/Savina/src/micro/Big.lf
+++ b/Cpp/Savina/src/micro/Big.lf
@@ -19,6 +19,7 @@
  *
  * @author Hannes Klein
  * @author Felix Wittwer
+ * @author Tassilo Tanneberger
  * @author Christian Menard
  */
 
@@ -56,13 +57,11 @@ reactor Sink(numWorkers:size_t(10)) {
     
     reaction(workerFinished) -> finished {=
         // collect all exit messages
-        for(const auto& port : workerFinished) {
-            if(port.is_present()) {
-                numMessages += 1;
-                if(numMessages == numWorkers) {
-                    finished.set();
-                    return;
-                }
+        for (auto i: workerFinished.active_ports_indices()) {
+            numMessages += 1;
+            if(numMessages == numWorkers) {
+                finished.set();
+                return;
             }
         }
     =}
@@ -98,24 +97,20 @@ reactor Worker(bank_index: size_t(0), numMessages: size_t(20000), numWorkers:siz
     
     // reply with pong
     reaction(inPing) -> outPong {=
-        for(size_t i{0}; i < numWorkers; i++) {
-            if (inPing[i].is_present()) { 
-                outPong[i].set();
-            }
+        for (auto i: inPing.active_ports_indices()) {
+            outPong[i].set();
         }
     =}
     
     // receive pong and send next ping
     reaction (inPong) -> next, finished {=
-        for(size_t i{0}; i < numWorkers; i++) {
-            if (inPong[i].is_present()) {
-                if (i != expPong) {
-                    reactor::log::Error() << "Expected pong from " << expPong 
-                                          << " but received pong from " << i;
-                }
+        for (auto i: inPong.active_ports_indices()) {
+            if (i != expPong) {
+                reactor::log::Error() << "Expected pong from " << expPong 
+                                      << " but received pong from " << i;
             }
         }
-        
+
         // send next ping
         if (numPings == numMessages) {
             finished.set();

--- a/Cpp/Savina/src/micro/Big.lf
+++ b/Cpp/Savina/src/micro/Big.lf
@@ -57,7 +57,7 @@ reactor Sink(numWorkers:size_t(10)) {
     
     reaction(workerFinished) -> finished {=
         // collect all exit messages
-        for (auto i: workerFinished.active_ports_indices()) {
+        for (auto i: workerFinished.get_present_port_indices()) {
             numMessages += 1;
             if(numMessages == numWorkers) {
                 finished.set();
@@ -97,14 +97,14 @@ reactor Worker(bank_index: size_t(0), numMessages: size_t(20000), numWorkers:siz
     
     // reply with pong
     reaction(inPing) -> outPong {=
-        for (auto i: inPing.active_ports_indices()) {
+        for (auto i: inPing.get_present_port_indices()) {
             outPong[i].set();
         }
     =}
-    
+
     // receive pong and send next ping
     reaction (inPong) -> next, finished {=
-        for (auto i: inPong.active_ports_indices()) {
+        for (auto i: inPong.get_present_port_indices()) {
             if (i != expPong) {
                 reactor::log::Error() << "Expected pong from " << expPong 
                                       << " but received pong from " << i;

--- a/Cpp/Savina/src/micro/Chameneos.lf
+++ b/Cpp/Savina/src/micro/Chameneos.lf
@@ -137,21 +137,19 @@ reactor ChameneosMallReactor(numMeetings:int(200000), numChameneos:int(5)) {
     
     reaction(inChameneos) -> pairChameneos, outFinished {=
         // detect all chameneos that are present
-        for(int i = 0; i < inChameneos.size(); ++i) {
-            if(inChameneos[i].is_present()) {
-                if(inChameneos[i].get()->type == MeetingCountMsg) {
-                    numFaded += 1;
-                    sumMeetings = sumMeetings + inChameneos[i].get()->id; // reuse id field
-                    if (numFaded == numChameneos) {
-                        outFinished.set();
-                        return;
-                    }
-                } else {
-                    messages[i] = inChameneos[i].get();
+        for (auto i: inChameneos.active_ports_indices()) {
+            if(inChameneos[i].get()->type == MeetingCountMsg) {
+                numFaded += 1;
+                sumMeetings = sumMeetings + inChameneos[i].get()->id; // reuse id field
+                if (numFaded == numChameneos) {
+                    outFinished.set();
+                    return;
                 }
+            } else {
+                messages[i] = inChameneos[i].get();
             }
         }
-        
+
         pairChameneos.schedule();
     =}
 }
@@ -205,11 +203,7 @@ reactor ChameneosChameneoReactor(bank_index:int(0), numChameneos:size_t(5)) {
         Message message;
         
         // find message
-        for(int i = 0; i < inChameneos.size(); i++) {
-            if(inChameneos[i].is_present()) {
-                message = *(inChameneos[i].get());
-            }
-        }
+        message = *(inChameneos[inChameneos.active_ports_indices()[0]].get());
         
         if(message.type == ChangeMsg) {
             color = message.color;

--- a/Cpp/Savina/src/micro/Chameneos.lf
+++ b/Cpp/Savina/src/micro/Chameneos.lf
@@ -137,7 +137,7 @@ reactor ChameneosMallReactor(numMeetings:int(200000), numChameneos:int(5)) {
     
     reaction(inChameneos) -> pairChameneos, outFinished {=
         // detect all chameneos that are present
-        for (auto i: inChameneos.active_ports_indices()) {
+        for (auto i: inChameneos.get_present_port_indices()) {
             if(inChameneos[i].get()->type == MeetingCountMsg) {
                 numFaded += 1;
                 sumMeetings = sumMeetings + inChameneos[i].get()->id; // reuse id field
@@ -203,7 +203,7 @@ reactor ChameneosChameneoReactor(bank_index:int(0), numChameneos:size_t(5)) {
         Message message;
         
         // find message
-        message = *(inChameneos[inChameneos.active_ports_indices()[0]].get());
+        message = *(inChameneos[inChameneos.get_present_port_indices()[0]].get());
         
         if(message.type == ChangeMsg) {
             color = message.color;

--- a/Cpp/Savina/src/parallelism/Apsp.lf
+++ b/Cpp/Savina/src/parallelism/Apsp.lf
@@ -130,8 +130,8 @@ reactor ApspFloydWarshallBlock(
     const method getElementAt(
         row: size_t,
         col: size_t,
-        rowPorts: {=const multiport::PortBankCallBack<reactor::Input<MatrixOfLong>>&=},
-        colPorts: {=const multiport::PortBankCallBack<reactor::Input<MatrixOfLong>>&=}
+        rowPorts: {=const reactor::Multiport<reactor::Input<MatrixOfLong>>&=},
+        colPorts: {=const reactor::Multiport<reactor::Input<MatrixOfLong>>&=}
     ): long {=
 
         size_t destRow = row / blockSize;

--- a/Cpp/Savina/src/parallelism/Apsp.lf
+++ b/Cpp/Savina/src/parallelism/Apsp.lf
@@ -14,6 +14,7 @@
  * 
  * @author Christian Menard
  * @author Hannes Klein
+ * @author Tassilo Tanneberger
  */
 
 target Cpp {
@@ -129,8 +130,8 @@ reactor ApspFloydWarshallBlock(
     const method getElementAt(
         row: size_t,
         col: size_t,
-        rowPorts: {=const std::vector<reactor::Input<MatrixOfLong>>&=},
-        colPorts: {=const std::vector<reactor::Input<MatrixOfLong>>&=}
+        rowPorts: {=const multiport::PortBankCallBack<reactor::Input<MatrixOfLong>>&=},
+        colPorts: {=const multiport::PortBankCallBack<reactor::Input<MatrixOfLong>>&=}
     ): long {=
 
         size_t destRow = row / blockSize;
@@ -247,6 +248,8 @@ main reactor (
                 numBlocksFinished++;
             }
         }
+
+        std::cout << "debug: " <<  matrix.finished.active_ports_indices().size() << " b:" << numBlocksFinished << std::endl;
         size_t dimension = numNodes / blockSize;
         if (numBlocksFinished == dimension*dimension) {
             runner.finished.set();

--- a/Cpp/Savina/src/parallelism/Apsp.lf
+++ b/Cpp/Savina/src/parallelism/Apsp.lf
@@ -249,7 +249,6 @@ main reactor (
             }
         }
 
-        std::cout << "debug: " <<  matrix.finished.active_ports_indices().size() << " b:" << numBlocksFinished << std::endl;
         size_t dimension = numNodes / blockSize;
         if (numBlocksFinished == dimension*dimension) {
             runner.finished.set();

--- a/Cpp/Savina/src/parallelism/FilterBank.lf
+++ b/Cpp/Savina/src/parallelism/FilterBank.lf
@@ -262,13 +262,10 @@ reactor Combine(numChannels: size_t{8}) {
         }
         outValue.set(sum);
     =}
-    
+
     reaction(inFinished) -> outFinished {=
-        for(const auto& port: inFinished) {
-            if(port.is_present()) {
-                numFinished++;
-            }
-        }
+        numFinished += inFinished.active_ports_indices().size();
+
         if(numFinished == numChannels) {
             outFinished.set();
             // reset local state

--- a/Cpp/Savina/src/parallelism/FilterBank.lf
+++ b/Cpp/Savina/src/parallelism/FilterBank.lf
@@ -264,7 +264,7 @@ reactor Combine(numChannels: size_t{8}) {
     =}
 
     reaction(inFinished) -> outFinished {=
-        numFinished += inFinished.active_ports_indices().size();
+        numFinished += inFinished.get_present_port_indices().size();
 
         if(numFinished == numChannels) {
             outFinished.set();

--- a/Cpp/Savina/src/parallelism/GuidedSearch.lf
+++ b/Cpp/Savina/src/parallelism/GuidedSearch.lf
@@ -127,7 +127,7 @@ reactor Manager(numWorkers: size_t{20}, gridSize: size_t{30}, priorities: size_t
     
     reaction (moreNodesToVisit) {=
         // collect more nodes to visit from all workers and store them in the internal queue
-        for (auto i: inPing.active_ports_indices()) {
+        for (auto i: moreNodesToVisit.active_ports_indices()) {
             const auto& nodes = *(moreNodesToVisit[i].get());
             if (!nodes.empty()) {
                 nodesToVisit.insert(nodesToVisit.end(), nodes.begin(), nodes.end());

--- a/Cpp/Savina/src/parallelism/GuidedSearch.lf
+++ b/Cpp/Savina/src/parallelism/GuidedSearch.lf
@@ -127,7 +127,7 @@ reactor Manager(numWorkers: size_t{20}, gridSize: size_t{30}, priorities: size_t
     
     reaction (moreNodesToVisit) {=
         // collect more nodes to visit from all workers and store them in the internal queue
-        for (auto i: moreNodesToVisit.active_ports_indices()) {
+        for (auto i: moreNodesToVisit.get_present_port_indices()) {
             const auto& nodes = *(moreNodesToVisit[i].get());
             if (!nodes.empty()) {
                 nodesToVisit.insert(nodesToVisit.end(), nodes.begin(), nodes.end());

--- a/Cpp/Savina/src/parallelism/GuidedSearch.lf
+++ b/Cpp/Savina/src/parallelism/GuidedSearch.lf
@@ -127,12 +127,10 @@ reactor Manager(numWorkers: size_t{20}, gridSize: size_t{30}, priorities: size_t
     
     reaction (moreNodesToVisit) {=
         // collect more nodes to visit from all workers and store them in the internal queue
-        for (auto& port : moreNodesToVisit) {
-            if (port.is_present()) {
-                const auto& nodes = *port.get();
-                if (!nodes.empty()) {
-                    nodesToVisit.insert(nodesToVisit.end(), nodes.begin(), nodes.end());
-                }
+        for (auto i: inPing.active_ports_indices()) {
+            const auto& nodes = *(moreNodesToVisit[i].get());
+            if (!nodes.empty()) {
+                nodesToVisit.insert(nodesToVisit.end(), nodes.begin(), nodes.end());
             }
         }
     =}

--- a/Cpp/Savina/src/parallelism/MatMul.lf
+++ b/Cpp/Savina/src/parallelism/MatMul.lf
@@ -129,12 +129,10 @@ reactor Manager(numWorkers: size_t{20}, dataLength: size_t{1024}) {
     
     reaction (moreWork) {=
         // append all work items received from the workers to the internal work queue
-        for (const auto& port : moreWork) {
-            if (port.is_present()) {
-                const auto& items = *port.get();
-                if (!items.empty()) {
-                    workQueue.insert(workQueue.end(), items.begin(), items.end());
-                }
+        for (auto i: moreWork.active_ports_indices()) {
+            const auto& items = *moreWork[i].get();
+            if (!items.empty()) {
+                workQueue.insert(workQueue.end(), items.begin(), items.end());
             }
         }
     =}

--- a/Cpp/Savina/src/parallelism/MatMul.lf
+++ b/Cpp/Savina/src/parallelism/MatMul.lf
@@ -129,7 +129,7 @@ reactor Manager(numWorkers: size_t{20}, dataLength: size_t{1024}) {
     
     reaction (moreWork) {=
         // append all work items received from the workers to the internal work queue
-        for (auto i: moreWork.active_ports_indices()) {
+        for (auto i: moreWork.get_present_port_indices()) {
             const auto& items = *moreWork[i].get();
             if (!items.empty()) {
                 workQueue.insert(workQueue.end(), items.begin(), items.end());

--- a/Cpp/Savina/src/parallelism/NQueens.lf
+++ b/Cpp/Savina/src/parallelism/NQueens.lf
@@ -33,6 +33,7 @@
  * complicate the design.
  * 
  * @author Christian Menard
+ * @author Tassilo Tanneberger
  * @author Hannes Klein
  */
 
@@ -138,11 +139,12 @@ reactor Manager(numWorkers: size_t{20}, solutionsLimit: size_t{1500000}, size: s
     reaction (solutionsFound) {=
         // accumulate all the solutions found
         size_t s{0};
-        for (const auto& port : solutionsFound) {
-            if (port.is_present()) {
-                s += *port.get();
-            }
+
+
+        for (auto i: solutionsFound.active_ports_indices()) {
+            s += *solutionsFound[i].get();
         }
+
         if (s > 0) {
             numSolutions += s;
             reactor::log::Info() << "Found " << s << " solutions; Total solutions: " << numSolutions;
@@ -151,12 +153,11 @@ reactor Manager(numWorkers: size_t{20}, solutionsLimit: size_t{1500000}, size: s
     
     reaction (moreWork) {=
         // append all work items received from the workers to the internal work queue
-        for (const auto& port : moreWork) {
-            if (port.is_present()) {
-                const auto& items = *port.get();
-                if (!items.empty()) {
-                    workQueue.insert(workQueue.end(), items.begin(), items.end());
-                }
+
+        for (auto i: moreWork.active_ports_indices()) {
+            const auto& items = *moreWork[i].get();
+            if (!items.empty()) {
+                workQueue.insert(workQueue.end(), items.begin(), items.end());
             }
         }
     =}

--- a/Cpp/Savina/src/parallelism/NQueens.lf
+++ b/Cpp/Savina/src/parallelism/NQueens.lf
@@ -141,7 +141,7 @@ reactor Manager(numWorkers: size_t{20}, solutionsLimit: size_t{1500000}, size: s
         size_t s{0};
 
 
-        for (auto i: solutionsFound.active_ports_indices()) {
+        for (auto i: solutionsFound.get_present_port_indices()) {
             s += *solutionsFound[i].get();
         }
 
@@ -154,7 +154,7 @@ reactor Manager(numWorkers: size_t{20}, solutionsLimit: size_t{1500000}, size: s
     reaction (moreWork) {=
         // append all work items received from the workers to the internal work queue
 
-        for (auto i: moreWork.active_ports_indices()) {
+        for (auto i: moreWork.get_present_port_indices()) {
             const auto& items = *moreWork[i].get();
             if (!items.empty()) {
                 workQueue.insert(workQueue.end(), items.begin(), items.end());

--- a/Cpp/Savina/src/parallelism/Trapezoidal.lf
+++ b/Cpp/Savina/src/parallelism/Trapezoidal.lf
@@ -60,7 +60,7 @@ reactor Manager(numWorkers:size_t(100), L:double(1.0), R:double(5.0), N:int(1000
     =}
     
     reaction(inWorkers) -> outFinished {=
-        for (auto i: inWorkers.active_ports_indices()) {
+        for (auto i: inWorkers.get_present_port_indices()) {
             numTermsReceived += 1;
             resultArea += *inWorkers[i].get();
         }

--- a/Cpp/Savina/src/parallelism/Trapezoidal.lf
+++ b/Cpp/Savina/src/parallelism/Trapezoidal.lf
@@ -3,6 +3,7 @@
  * 
  * @author Hannes Klein
  * @author Felix Wittwer
+ * @author Tassilo Tanneberger
  */
 
 target Cpp {
@@ -11,7 +12,6 @@ target Cpp {
 };
 
 import BenchmarkRunner from "../BenchmarkRunner.lf";
-
 
 public preamble {=
     struct WorkMessage {
@@ -60,13 +60,11 @@ reactor Manager(numWorkers:size_t(100), L:double(1.0), R:double(5.0), N:int(1000
     =}
     
     reaction(inWorkers) -> outFinished {=
-        for(int i = 0; i < inWorkers.size(); ++i) {
-            if(inWorkers[i].is_present()) {
-                numTermsReceived += 1;
-                resultArea += *inWorkers[i].get();
-            }
+        for (auto i: inWorkers.active_ports_indices()) {
+            numTermsReceived += 1;
+            resultArea += *inWorkers[i].get();
         }
-        
+
         if(numTermsReceived == numWorkers) {
             reactor::log::Info() << "Area: " << resultArea;
             outFinished.set();


### PR DESCRIPTION
# Multiport Optimizations

This pull request replaces the old and inefficient search for present ports by the `get_present_port_indices` method, which uses the new book keeping functionality. This wages are aimed to fix the lack of performance from sparse multiports.   

## Related To

- https://github.com/lf-lang/lingua-franca/pull/1312
- https://github.com/lf-lang/reactor-cpp/pull/24

