### PR TITLE
bugfix in Apsp; don't notify neighbours when computation finished

### DIFF
--- a/C/Savina/src/parallelism/Apsp.lf
+++ b/C/Savina/src/parallelism/Apsp.lf
@@ -191,10 +191,10 @@ reactor ApspFloydWarshallBlock(
                 }
             }
             SET(finished, true);
+        } else {
+            // send the result to all neighbors in the next iteration
+            lf_schedule_copy(notify_neighbors, 0, &local_matrix, 1);
         }
-
-        // send the result to all neighbors in the next iteration
-        lf_schedule_copy(notify_neighbors, 0, &local_matrix, 1);
     =}
     reaction(shutdown) {=
         mat_destroy_i(self->local_matrix_block);

--- a/Cpp/Savina/src/parallelism/Apsp.lf
+++ b/Cpp/Savina/src/parallelism/Apsp.lf
@@ -106,10 +106,10 @@ reactor ApspFloydWarshallBlock(
                 }
             }
             finished.set();
+        } else {
+            // send the result to all neighbors in the next iteration
+            notifyNeighbors.schedule(std::move(matrix));        
         }
-       
-        // send the result to all neighbors in the next iteration
-        notifyNeighbors.schedule(std::move(matrix));        
     =}
 
     // Extract (copy) the data block that is relevant for this instance from the given matrix 


### PR DESCRIPTION
This fixes a bug in Apsp, where the computation reaction schedules again `notify_neighbours` even if the computation finished. This call to schedule in `notify_neighbors` overlaps with the call to schedule in the reaction to `start`. Apparently, this didn't trigger any observable errors, but the work conducted wasn't 'correct'.