### PR TITLE
Let there be no non-keyword target_link_libraries.

### DIFF
--- a/C/Savina/src/parallelism/PiPrecision.cmake
+++ b/C/Savina/src/parallelism/PiPrecision.cmake
@@ -1,1 +1,1 @@
-target_link_libraries(${LF_MAIN_TARGET} gmpxx gmp)
+target_link_libraries(${LF_MAIN_TARGET} PRIVATE gmpxx gmp)


### PR DESCRIPTION
This is due to an incompatibility between the two flavors of the API.
The modern flavor is preferred and required for compatibility with
Python libs, so I am sticking with that.