### PR TITLE
Fix Radix Sort Rust benchmark

### DIFF
--- a/Rust/Savina/src/parallelism/RadixSort.lf
+++ b/Rust/Savina/src/parallelism/RadixSort.lf
@@ -160,8 +160,7 @@ reactor ValidationReactor(num_values: usize(100000)) {
     =}
 }
 
-//                                                        vvvv == 1u64 << 60
-main reactor (num_iterations: usize(12), num_values: usize(100000), max_value: i64({= 1152921504606846976 =}), num_bits: usize(60), seed: i64(2048)) {
+main reactor (num_iterations: usize(12), num_values: usize(100000), max_value: u64({= 1u64 << 60 =}), num_bits: usize(60), seed: i64(2048)) {
     state num_iterations(num_iterations);
     state num_values(num_values);
     state max_value(max_value);

--- a/Rust/Savina/src/parallelism/RadixSort.lf
+++ b/Rust/Savina/src/parallelism/RadixSort.lf
@@ -20,7 +20,7 @@ target Rust {
 import BenchmarkRunner from "../lib/BenchmarkRunner.lf";
 
 
-reactor IntSourceReactor(num_values: usize(100000), max_value: i64({= 1_i64 << 60 =}), seed: i64(2048)) {
+reactor IntSourceReactor(num_values: usize(100000), max_value: u64({= 1_u64 << 60 =}), seed: i64(2048)) {
     state seed(seed);
 
     preamble {=
@@ -47,8 +47,8 @@ reactor IntSourceReactor(num_values: usize(100000), max_value: i64({= 1_i64 << 6
     =}
 
     // @label gen_random
-    reaction(startup, sendRandomNum) -> outValue, sendRandomNum {=
-        let value = self.random.next_in_range(0..self.max_value).into();
+    reaction(sendRandomNum) -> outValue, sendRandomNum {=
+        let value = self.random.next_in_range(0..(self.max_value as i64)).into();
         ctx.set(outValue, value);
         self.num_sent_values += 1;
 


### PR DESCRIPTION
Fixing reaction plan merging via https://github.com/lf-lang/reactor-rs/pull/28 unearthed an issue with this benchmark.
One of the reactions uses the `startup` trigger, when this should only be used by the benchmark runner. This was probably an oversight when the porting to the benchmark runner was done.