### PR TITLE
Fetch entire Git history.

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -29,6 +29,7 @@ jobs:
           submodules: true
           ref: ${{ inputs.compiler-ref }}
           path: lf
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./lf/.github/actions/prepare-build-env
       - name: Setup Python


### PR DESCRIPTION
This is needed by #1374 in lf-lang/lingua-franca.

It is a stopgap measure to get tests to keep passing until we reformat the entire code base and remove the `ratchet-from` option from our Spotless Gradle configuration.