### PR TITLE
Give CI job a descriptive name

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -12,9 +12,9 @@ on:
       benchmarks-ref:
         required: false
         type: string
-    
+
 jobs:
-  run:
+  benchmark-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out benchmarks
@@ -33,11 +33,11 @@ jobs:
       - name: Prepare build environment
         uses: ./lf/.github/actions/prepare-build-env
       - name: Setup Python
-        uses: actions/setup-python@v4 
+        uses: actions/setup-python@v4
         with:
-            python-version: '3.10' 
+            python-version: '3.10'
       - name: Install Python dependencies
-        run: pip3 install -r runner/requirements.txt      
+        run: pip3 install -r runner/requirements.txt
       - name: Build lfc
         run: |
           cd lf


### PR DESCRIPTION
With additional levels of hierarchy in Github Actions, the names of individual jobs are shown in place of what were informative names. Therefore, I have moved in the direction of giving jobs informative names.