### PR TITLE
Fix rug usage in Rust PiPrecision

### DIFF
--- a/Rust/Savina/src/parallelism/PiPrecision.lf
+++ b/Rust/Savina/src/parallelism/PiPrecision.lf
@@ -32,10 +32,13 @@ reactor Manager(numWorkers: usize = 20, scale: u32 = 5000) {
   state scale = scale
   // Precision is 2 bits higher than in C++ implementation,
   // only this way do we get the correct result.
-  state precision: u32 = {= 16610 + 2 =}
+  preamble {=
+    const PRECISION: u32 = 16610 + 2;
+    const PRECISIONI64: i64 = PRECISION as i64;
+  =}
 
-  state result: Float = {= Float::new(precision) =}
-  state tolerance: Float = {= Float::new(precision) =}
+  state result: Float = {= Float::new(PRECISION) =}
+  state tolerance: Float = {= Float::new(PRECISION) =}
   state termsRequested: u32 = 0
 
   input start: unit
@@ -56,7 +59,7 @@ reactor Manager(numWorkers: usize = 20, scale: u32 = 5000) {
 
   reaction(startup) {=
     // initialization
-    self.tolerance = 1u32 / Float::with_val(self.precision, 10u32).pow(self.scale);
+    self.tolerance = 1u32 / Float::with_val(PRECISION, 10u32).pow(self.scale);
   =}
 
   reaction(done) -> finished {=
@@ -78,7 +81,7 @@ reactor Manager(numWorkers: usize = 20, scale: u32 = 5000) {
 
   reaction(start) -> next {=
     // reset local state
-    self.result = Float::new(self.precision);
+    self.result = Float::new(PRECISION);
     self.termsRequested = 0;
     // start execution
     ctx.schedule(next, Asap);
@@ -97,7 +100,7 @@ reactor Manager(numWorkers: usize = 20, scale: u32 = 5000) {
     for port in response {
         if let Some(x) = ctx.use_ref_opt(port, Clone::clone) {
             self.result += x.as_ref();
-            if (x.as_ref() - &self.tolerance).complete(self.precision) < 0u32 {
+            if (x.as_ref() - &self.tolerance).complete(PRECISIONI64) < 0u32 {
                 stop = true;
             }
         }
@@ -128,11 +131,11 @@ reactor Worker {
         let two = Float::with_val(PRECISION, 2u32);
         let one = Float::with_val(PRECISION, 1u32);
 
-        let mut term = Float::new(PRECISION);
-        term = (&four / (eight_k + 1)).complete(PRECISION);
-        term -= (&two / (eight_k + 4)).complete(PRECISION);
-        term -= (&one / (eight_k + 5)).complete(PRECISION);
-        term -= (&one / (eight_k + 6)).complete(PRECISION);
+        const PREC_I64 : i64 = PRECISION as i64;
+        let mut term: Float = (&four / (eight_k + 1)).complete(PREC_I64);
+        term -= (&two / (eight_k + 4)).complete(PREC_I64);
+        term -= (&one / (eight_k + 5)).complete(PREC_I64);
+        term -= (&one / (eight_k + 6)).complete(PREC_I64);
 
         let mut sixteen_pow = Float::with_val(PRECISION, 16u32).pow(k);
         term /= sixteen_pow;


### PR DESCRIPTION
These were compilation errors that I have locally. I suppose that could be why the benchmark is failing in https://github.com/lf-lang/lingua-franca/actions/runs/10018708034, although I'm not sure why it would suddenly have started failing. The rug dependency didn't change its API.

CC @lhstrh 