### PR TITLE
Use fixed Rust version to run benchmarks

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.87.0
           components: clippy
           rustflags: "" # don't use -D warnings
         if: ${{ inputs.target == 'Rust' }}


### PR DESCRIPTION
This prevents nightly from breaking the build in this and in the main repo when the compiler or clippy get a new warning/error.

https://github.com/lf-lang/reactor-rs/pull/53 and https://github.com/lf-lang/lingua-franca/pull/2520 this should fix the build issues in the main repo. This PR is about preventing this in the future.

Replaces #70 and #71 